### PR TITLE
[AttestationVerifier] Check attestation existence first

### DIFF
--- a/src/libraries/AttestationVerifier.sol
+++ b/src/libraries/AttestationVerifier.sol
@@ -23,6 +23,11 @@ library AttestationVerifier {
      * @param attestation Full EAS attestation to verify.
      */
     function verifyAttestation(Attestation memory attestation) internal view {
+        // Attestation must exist.
+        if (attestation.uid == 0) {
+            revert AttestationNotFound();
+        }
+
         _verifyAttestation(attestation);
     }
 
@@ -39,6 +44,11 @@ library AttestationVerifier {
      * @param schemaUid Unique identifier of the expected schema.
      */
     function verifyAttestation(Attestation memory attestation, address recipient, bytes32 schemaUid) internal view {
+        // Attestation must exist.
+        if (attestation.uid == 0) {
+            revert AttestationNotFound();
+        }
+
         // Attestation being checked must be for the expected recipient.
         if (attestation.recipient != recipient) {
             revert AttestationRecipientMismatch(attestation.recipient, recipient);
@@ -52,11 +62,6 @@ library AttestationVerifier {
     }
 
     function _verifyAttestation(Attestation memory attestation) private view {
-        // Attestation must exist.
-        if (attestation.uid == 0) {
-            revert AttestationNotFound();
-        }
-
         // Attestation must not be expired.
         if (attestation.expirationTime != 0 && attestation.expirationTime <= block.timestamp) {
             revert AttestationExpired(attestation.uid, attestation.expirationTime);


### PR DESCRIPTION
What

Always checks to see if the attestation exists first so that both `verifyAttestation` functions share the same behaviour and revert with AttestationNotFound.

Why

Currently when `function verifyAttestation(Attestation memory attestation, address recipient, bytes32 schemaUid)` is called with an empty attestation, it will revert with `AttestationRecipientMismatch`, which is confusing in the case of an empty attestation. So we want to make sure to always check the attestation uid first to ensure attestation exists.