### PR TITLE
Ensure we check if an attestation exists before other checks

### DIFF
--- a/src/interfaces/IAttestationIndexer.sol
+++ b/src/interfaces/IAttestationIndexer.sol
@@ -16,7 +16,7 @@ interface IAttestationIndexer {
     /**
      * @notice Retrieves an EAS attestation unique identifier by the recipient and schema.
      * @dev Intended for guarded / permissioned EAS schemas.
-     * That is, any attesters / issuer of attestations for a specific schema are trusted
+     * That is, any attesters / issuers of attestations for a specific schema are trusted
      * because the schema is protected by a resolver.
      *
      * The attestation unique identifier can be used to retrieve the

--- a/src/libraries/AttestationVerifier.sol
+++ b/src/libraries/AttestationVerifier.sol
@@ -23,6 +23,11 @@ library AttestationVerifier {
      * @param attestation Full EAS attestation to verify.
      */
     function verifyAttestation(Attestation memory attestation) internal view {
+        // Attestation must exist.
+        if (attestation.uid == 0) {
+            revert AttestationNotFound();
+        }
+
         _verifyAttestation(attestation);
     }
 
@@ -39,6 +44,10 @@ library AttestationVerifier {
      * @param schemaUid Unique identifier of the expected schema.
      */
     function verifyAttestation(Attestation memory attestation, address recipient, bytes32 schemaUid) internal view {
+        // Attestation must exist.
+        if (attestation.uid == 0) {
+            revert AttestationNotFound();
+        }
         // Attestation being checked must be for the expected recipient.
         if (attestation.recipient != recipient) {
             revert AttestationRecipientMismatch(attestation.recipient, recipient);
@@ -52,11 +61,6 @@ library AttestationVerifier {
     }
 
     function _verifyAttestation(Attestation memory attestation) private view {
-        // Attestation must exist.
-        if (attestation.uid == 0) {
-            revert AttestationNotFound();
-        }
-
         // Attestation must not be expired.
         if (attestation.expirationTime != 0 && attestation.expirationTime <= block.timestamp) {
             revert AttestationExpired(attestation.uid, attestation.expirationTime);


### PR DESCRIPTION
Otherwise, we can return an attestation mismatch error rather than the more appropriate not found error.

Original changes by @qiwu7